### PR TITLE
Remove Borders from VisualTable course cells

### DIFF
--- a/src/main/js/components/ScheduleVisualTable.jsx
+++ b/src/main/js/components/ScheduleVisualTable.jsx
@@ -160,7 +160,7 @@ class ScheduleVisualTable extends React.Component {
 
 ScheduleVisualTable.CourseCell = ({ meetingData }) => (
   <td
-    className="bordered meeting-cell"
+    className="meeting-cell"
     rowSpan={(meetingData.timeSlot.endNum - meetingData.timeSlot.startNum) / 5}
     style={{ backgroundColor: meetingData.color }}
   >


### PR DESCRIPTION
Due to #11, I am removing the borders from the visual table course cells until a fix is found.